### PR TITLE
Add binding on main queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Lightweight collection of helpers and tools to make working with Apple's Combine
 Please feel free to request some nice-to-have features or point out the things that need improvement.
 ## What's included
 ### BindingObject
-Class-bound protocol that provides a `bind` method to use instead of the standard `sink`+`store` to make call sites cleaner.  
-Example, instead of this
+Class-bound protocol that provides `bind` methods to use instead of the standard `sink`+`store` to make call sites cleaner.  
+For example, instead of this
 ```swift5
 somePublisher
     .sink { [weak self] value in
@@ -18,3 +18,4 @@ bind(somePublisher) { [weak self] value in
     self?.doSomething(with: value)
 }
 ```
+`bindOnMainQueue` accomplishes the same but receives on the `DispatchQueue.main` scheduler.

--- a/Sources/Combineer/BindingObject.swift
+++ b/Sources/Combineer/BindingObject.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 
 /// Provides conforming values with `bind` method implementation to simplify subscriptions.
 public protocol BindingObject: AnyObject {
@@ -25,5 +26,19 @@ extension BindingObject {
         publisher
             .sink(receiveCompletion: completionHandler, receiveValue: valueHandler)
             .store(in: &cancellables)
+    }
+
+    /// Attaches subscriber with passed handler closures, receiving on `DispatchQueue.main` without options
+    /// and stores it in `cancellables`.
+    /// - parameter publisher: Publisher to subscribe `self` to.
+    /// - parameter valueHandler: Closure that handles value received from the publisher.
+    /// - parameter completionHandler: Closure that handles completion sent by the publisher.
+    public func bindOnMainQueue<BindablePublisher: Publisher>(
+        _ publisher: BindablePublisher,
+        valueHandler: @escaping (BindablePublisher.Output) -> Void,
+        completionHandler: @escaping (Subscribers.Completion<BindablePublisher.Failure>) -> Void = { _ in }
+    ) {
+        let publisherOnMainQueue = publisher.receive(on: DispatchQueue.main)
+        bind(publisherOnMainQueue, valueHandler: valueHandler, completionHandler: completionHandler)
     }
 }

--- a/Tests/CombineerTests/BindingObjectTests.swift
+++ b/Tests/CombineerTests/BindingObjectTests.swift
@@ -3,17 +3,82 @@ import XCTest
 @testable import Combineer
 
 final class BindingObjectTests: XCTestCase {
-    typealias SUT = BindingObject
+    private var sut: MockBindingObject!
+    private var stringPulisher: Publishers.Sequence<String, Never>!
+    private var stringSubject: PassthroughSubject<String, Never>!
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        sut = MockBindingObject()
+        stringPulisher = "".publisher
+        stringSubject = PassthroughSubject<String, Never>()
+    }
+
+    override func tearDown() {
+        sut = nil
+        stringPulisher = nil
+        stringSubject = nil
+    }
+
+    // MARK: - Test bind
 
     func test_bind_storesSubscriptionInCancellables() {
-        let object = MockBindingObject()
-        object.bind("".publisher, valueHandler: { _ in })
-        XCTAssertEqual(object.cancellables.count, 1)
+        sut.bind(stringPulisher, valueHandler: { _ in })
+        XCTAssertEqual(sut.cancellables.count, 1)
+    }
+
+    func test_bind_assignsCorrectReceiveHandler() {
+        let passedValue = "passed value"
+        let expectation = makeReceivedValueExpectation()
+
+        sut.bind(stringSubject) { value in
+            XCTAssertEqual(value, passedValue)
+            expectation.fulfill()
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.stringSubject.send(passedValue)
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - Test bindOnMainQueue
+
+    func test_bindOnMainQueue_storesSubscriptionInCancellables() {
+        sut.bindOnMainQueue(stringPulisher, valueHandler: { _ in })
+        XCTAssertEqual(sut.cancellables.count, 1)
+    }
+
+    func test_bindOnMainQueue_whenValueSentFromOtherQueue_receivesOnMainQueue() {
+        let expectation = makeReceivedValueExpectation()
+
+        sut.bindOnMainQueue(stringSubject) { _ in
+            XCTAssert(Thread.current.isMainThread, "Not on main thread.")
+            expectation.fulfill()
+        }
+
+        DispatchQueue.global().async { [weak self] in
+            self?.stringSubject.send("123")
+        }
+
+        wait(for: [expectation], timeout: 1)
     }
 }
 
+// MARK: - Private Methods
+
 extension BindingObjectTests {
-    final class MockBindingObject: BindingObject {
+    private func makeReceivedValueExpectation() -> XCTestExpectation {
+        expectation(description: "Receive value from publisher")
+    }
+}
+
+// MARK: - Helpers
+
+extension BindingObjectTests {
+    private final class MockBindingObject: BindingObject {
         var cancellables: Set<AnyCancellable> = []
     }
 }


### PR DESCRIPTION
Added `bindOnMainQueue` method to include receiving on `DispatchQueue.main`.