### PR TITLE
Add binding to subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,8 @@ bind(somePublisher) { [weak self] value in
     self?.doSomething(with: value)
 }
 ```
-`bindOnMainQueue` accomplishes the same but receives on the `DispatchQueue.main` scheduler.
+`bindOnMainQueue` accomplishes the same but receives on the `DispatchQueue.main` scheduler.  
+`bind(_:, to:)` method allows passing the value of a publisher to a subject:  
+```
+bind(myPublisher, to: mySubject)
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ bind(somePublisher) { [weak self] value in
 }
 ```
 `bindOnMainQueue` accomplishes the same but receives on the `DispatchQueue.main` scheduler.  
+
 `bind(_:, to:)` and `bindOnMainQueue(_:, to:)` methods allow passing the value of a publisher to a subject:  
 ```
 bind(myPublisher, to: mySubject)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bind(somePublisher) { [weak self] value in
 }
 ```
 `bindOnMainQueue` accomplishes the same but receives on the `DispatchQueue.main` scheduler.  
-`bind(_:, to:)` method allows passing the value of a publisher to a subject:  
+`bind(_:, to:)` and `bindOnMainQueue(_:, to:)` methods allow passing the value of a publisher to a subject:  
 ```
 bind(myPublisher, to: mySubject)
 ```

--- a/Sources/Combineer/BindingObject.swift
+++ b/Sources/Combineer/BindingObject.swift
@@ -42,6 +42,15 @@ extension BindingObject {
         bind(publisherOnMainQueue, valueHandler: valueHandler, completionHandler: completionHandler)
     }
 
+    /// Attaches the output of a publisher to a subject and stores the subscription in `cancellables.
+    ///
+    /// Example:
+    /// ```
+    ///  bind(publisher, to: subject)
+    /// ```
+    ///
+    /// - parameter publisher: Publisher that will be sending values to subject.
+    /// - parameter subject: Subject that will receive values from the attached publisher.
     public func bind<BindablePublisher: Publisher, ReceivingSubject: Subject>(
         _ publisher: BindablePublisher,
         to subject: ReceivingSubject

--- a/Sources/Combineer/BindingObject.swift
+++ b/Sources/Combineer/BindingObject.swift
@@ -41,4 +41,15 @@ extension BindingObject {
         let publisherOnMainQueue = publisher.receive(on: DispatchQueue.main)
         bind(publisherOnMainQueue, valueHandler: valueHandler, completionHandler: completionHandler)
     }
+
+    public func bind<BindablePublisher: Publisher, ReceivingSubject: Subject>(
+        _ publisher: BindablePublisher,
+        to subject: ReceivingSubject
+    ) where ReceivingSubject.Output == BindablePublisher.Output,
+            ReceivingSubject.Failure == BindablePublisher.Failure {
+
+                publisher
+                    .subscribe(subject)
+                    .store(in: &cancellables)
+            }
 }

--- a/Sources/Combineer/BindingObject.swift
+++ b/Sources/Combineer/BindingObject.swift
@@ -61,4 +61,24 @@ extension BindingObject {
                     .subscribe(subject)
                     .store(in: &cancellables)
             }
+
+    /// Attaches the output of a publisher  received on `DispatchQueue.main` to a subject (without options)
+    /// and stores the subscription in `cancellables.
+    ///
+    /// Example:
+    /// ```
+    ///  bindOnMainQueue(publisher, to: subject)
+    /// ```
+    ///
+    /// - parameter publisher: Publisher that will be sending values to subject.
+    /// - parameter subject: Subject that will receive values from the attached publisher.
+    public func bindOnMainQueue<BindablePublisher: Publisher, ReceivingSubject: Subject>(
+        _ publisher: BindablePublisher,
+        to subject: ReceivingSubject
+    ) where ReceivingSubject.Output == BindablePublisher.Output,
+            ReceivingSubject.Failure == BindablePublisher.Failure {
+
+                let publisher = publisher.receive(on: DispatchQueue.main)
+                bind(publisher, to: subject)
+            }
 }


### PR DESCRIPTION
**In this PR:**
- Added methods methods to `BindingObject` that allow passing value from publisher to a subject with one line of code:

```swift
bind(somePublisher, to: someSubject)
```

**TBD:**
1. Add more tests for the methods from `BindingObject`.
2. Improve comments and README description.